### PR TITLE
Recover compatibility for NotificationService

### DIFF
--- a/spar-wings-sns-notification/build.gradle
+++ b/spar-wings-sns-notification/build.gradle
@@ -4,6 +4,7 @@ description "Amazon SNS client wrapper to notify messages to developers or opera
 
 dependencies {
 	compile "com.amazonaws:aws-java-sdk-sns:$awsJavaSdkVersion"
+	testCompile "org.springframework:spring-context:$springVersion"
 	compile project(":spar-wings-spring-essential")
 	compile project(":spar-wings-aws-essential")
 }

--- a/spar-wings-sns-notification/src/main/java/jp/xet/sparwings/aws/sns/NotificationService.java
+++ b/spar-wings-sns-notification/src/main/java/jp/xet/sparwings/aws/sns/NotificationService.java
@@ -92,13 +92,13 @@ public class NotificationService implements InitializingBean {
 	@Value("#{systemEnvironment['OPS_TOPIC_ARN'] ?: systemProperties['OPS_TOPIC_ARN']}")
 	String deprecatedOpsTopicArn;
 	
-	@Value("${sparwings.notification.stack-name}")
+	@Value("${sparwings.notification.stack-name:#{null}}")
 	String stackName;
 	
-	@Value("${sparwings.notification.dev}")
+	@Value("${sparwings.notification.dev:#{null}}")
 	String devTopicArn;
 	
-	@Value("${sparwings.notification.ops}")
+	@Value("${sparwings.notification.ops:#{null}}")
 	String opsTopicArn;
 	
 	

--- a/spar-wings-sns-notification/src/test/java/jp/xet/sparwings/aws/sns/NotificationServiceTest.java
+++ b/spar-wings-sns-notification/src/test/java/jp/xet/sparwings/aws/sns/NotificationServiceTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jp.xet.sparwings.aws.sns;
+
+import static org.mockito.Mockito.mock;
+
+import org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
+
+import org.junit.Test;
+
+import com.amazonaws.services.sns.AmazonSNS;
+
+import jp.xet.sparwings.spring.env.EnvironmentService;
+
+public class NotificationServiceTest {
+	
+	@Test
+	public void test() {
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(TestConfiguration.class);
+		context.getBean(NotificationService.class);
+	}
+	
+	
+	@Configuration
+	public static class TestConfiguration {
+		
+		@Bean
+		public PropertySourcesPlaceholderConfigurer propertysourcePlaceholderConfigurer() {
+			return new PropertySourcesPlaceholderConfigurer();
+		}
+		
+		@Bean
+		public AutowiredAnnotationBeanPostProcessor postProcessor() {
+			
+			return new AutowiredAnnotationBeanPostProcessor();
+		}
+		
+		@Bean
+		public NotificationService notificationService() {
+			return new NotificationService(mock(AmazonSNS.class), "sample-app", mock(EnvironmentService.class));
+		}
+	}
+}


### PR DESCRIPTION

NotificationService breaks compatibility between 0.32 and 0.34.
So, this PR will recover compatibility.

# Expected and Actual

Expected: 

no exception occurs if ${sparwings.notification.ops}, ${sparwings.notification.dev} and ${sparwings.notification.stack-name} has no value in spring's Environment.

Actual:

BeanCreationException that value cannot resolve occured.